### PR TITLE
Optimize group randomizer functions

### DIFF
--- a/app/handlers/grouping/randomizer.py
+++ b/app/handlers/grouping/randomizer.py
@@ -96,6 +96,9 @@ def get_eligible_integer_compositions(
     - For (strict) compositions, use the restriction function f(x) = 1.
     - For partitions, use the restriction function f(x) = x.
 
+    For more explanation on the sigma restriction function, see Equation
+    (3.1) from here: https://jeromekelleher.net/downloads/k06.pdf#page=58
+
     Each group sizes configuration has an equal, uniform probability of
     being chosen. Hence, there would be no bias towards any specific
     grouping configuration (either balanced or maximum). Technically,
@@ -132,7 +135,7 @@ def get_eligible_integer_compositions(
             k += 1
         a[k] = x + y
         z = a[: k + 1]
-        if min(z) >= min_value and max(z) <= max_value:
+        if (z[0] >= min_value) and (z[-1] <= max_value):
             yield z
 
 
@@ -241,8 +244,8 @@ def get_random_groupings(
         possible_group_sizes_configurations = list(
             get_eligible_integer_compositions(
                 channel_size,
-                1,
-                lambda x: 1,
+                settings.MIN_GROUP_SIZE,
+                lambda x: x,
                 settings.MIN_GROUP_SIZE,
                 settings.MAX_GROUP_SIZE,
             )

--- a/app/settings.py
+++ b/app/settings.py
@@ -57,7 +57,7 @@ MIN_GROUP_SIZE = 3
 MAX_GROUP_SIZE = 5
 
 # This threshold is arbitrarily chosen
-RANDOMIZER_CHANNEL_SIZE_THRESHOLD = 23
+RANDOMIZER_CHANNEL_SIZE_THRESHOLD = 70
 
 # Limit to number of digits for scores
 # Upper limit of INTEGER(11) has 10 digits, however maximum score is 100 (with 3 digits)


### PR DESCRIPTION
This commit adds several slight optimizations for the group randomizer:

1. Generate partitions instead of compositions since it requires less memory (and hence, faster) and since we shuffle the selected configuration anyway. This is because for a given non-negative integer n, the partition function `p(n)` is always less than or equal to the number of compositions of n (1 for 0, 2^(n-1) for n>=1).

2. For integer partitions, the sigma restriction function would impose the parts to be monotonically increasing (non-decreasing). Hence, we can remove the usage of `min()` and `max()` (which have O(n) time complexity), and instead, we can simply only check the first and last parts (with O(1) time complexity).

3. Set `m = settings.MIN_GROUP_SIZE` since this would prevent the generation of integer partitions where the first part is less than the minimum value, allowing us to use even less memory space.

The value of `settings.RANDOMIZER_CHANNEL_SIZE_THRESHOLD` has also been increased accordingly since we can now afford to properly randomize channels of larger sizes.